### PR TITLE
Fix request length calculation for pcap2ammo tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ build/
 dist/
 *.egg-info/
 env/
-
+.idea

--- a/tanktools/pcap2ammo.py
+++ b/tanktools/pcap2ammo.py
@@ -101,6 +101,24 @@ def pcap2ammo(args):
     return 0
 
 
+def normalize_header_arg(header):
+    """Remover enclosing quotes for header
+       and transform it to the lower case
+
+    Args:
+        header (str): header with (or without) enclosing quotes
+
+    Returns:
+        str: header without enclosing quotes in lower case
+    """
+    norm_header = header.lower()
+    if norm_header.startswith('"') or norm_header.startswith("'"):
+        norm_header = norm_header[1:]
+    if norm_header.endswith('"') or norm_header.endswith("'"):
+        norm_header = norm_header[:-1]
+    return norm_header
+
+
 def delete_headers(request, headers):
     """Delete headers from http packet
 
@@ -113,7 +131,7 @@ def delete_headers(request, headers):
     """
 
     for header in headers:
-        norm_header = header.lower()[1:-1]
+        norm_header = normalize_header_arg(header)
         if norm_header in request.headers:
             del request.headers[norm_header]
     return request
@@ -132,7 +150,8 @@ def add_headers(request, headers):
     """
 
     for header in headers:
-        header_parts = re.split(r": *", header[1:-1], 1)
+        norm_header = normalize_header_arg(header)
+        header_parts = re.split(r": *", norm_header, 1)
         if len(header_parts) == 2:
             header_name = header_parts[0].lower()
             header_value = header_parts[1]

--- a/tanktools/pcap2ammo.py
+++ b/tanktools/pcap2ammo.py
@@ -86,6 +86,10 @@ def pcap2ammo(args):
                     delete_headers(request, args['delete_header'])
                 if 'add_header' in args and args['add_header']:
                     add_headers(request, args['add_header'])
+                if 'content-type' in request.headers:
+                    if request.headers['content-type'].lower().find('multipart/form-data') >= 0:
+                        delete_headers(request, ["'content-length'"])
+                        add_headers(request, ["'content-length: " + str(len(bytes(request.body, encoding="utf_8"))) + "'"])
                 file_handler.write(make_ammo(request))
     except ValueError as e:
         sys.stderr.write('Error: ' + str(e) + "\n")

--- a/tanktools/pcap2ammo.py
+++ b/tanktools/pcap2ammo.py
@@ -160,7 +160,8 @@ def make_ammo(request, case=''):
         "%d %s\n"
         "%s"
     )
-    return ammo_template % (len(request), case, request)
+    request_length = len(bytes(request, encoding="utf_8"))
+    return ammo_template % (request_length, case, request)
 
 
 def main():


### PR DESCRIPTION
Yandex Tank expects the request size in bytes (in utf-8 encoding) whereas the tool calculates size as count of characters in the request. This solution worked for most of requests because they contained only 1-byte characters. Unfortunately, UTF-8 uses 1-4 bytes per character in general.